### PR TITLE
Update editor.selectionBackground color in Solarized-light.json

### DIFF
--- a/themes/Solarized-light.json
+++ b/themes/Solarized-light.json
@@ -124,7 +124,7 @@
   "colors": {
     "editor.foreground": "#586E75",
     "editor.background": "#FDF6E3",
-    "editor.selectionBackground": "#073642",
+    "editor.selectionBackground": "#EEE8D5",
     "editor.lineHighlightBackground": "#EEE8D5",
     "editorCursor.foreground": "#000000",
     "editorWhitespace.foreground": "#93A1A1"


### PR DESCRIPTION
It seems that the highlight color for solorized light was using the highlight color from solorized dark.

<img width="616" alt="Screen Shot 2019-06-27 at 5 03 44 PM" src="https://user-images.githubusercontent.com/5674135/60304429-18b35880-98ff-11e9-85a0-25e709996dc0.png">

This change updates it.

<img width="616" alt="Screen Shot 2019-06-27 at 5 04 30 PM" src="https://user-images.githubusercontent.com/5674135/60304447-1fda6680-98ff-11e9-801c-faa20c34ea54.png">
