### PR TITLE
Monokai theme support minimap background color

### DIFF
--- a/themes/Monokai.json
+++ b/themes/Monokai.json
@@ -3,6 +3,10 @@
   "inherit": true,
   "rules": [
     {
+      "token": "",
+      "background": "F8F8F2",
+    },
+    {
       "foreground": "75715e",
       "token": "comment"
     },


### PR DESCRIPTION
Minimap background color keeps the same with editor background color，In fact,  all themes whose editor background color is inconsistent with the inherited theme's background color should be treated like this.